### PR TITLE
use host's dns

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,12 +8,10 @@ Vagrant.configure("2") do |config|
     ENV[key] ? ["--#{hw}", ENV[key]] : []
   end.flatten
 
-  if not vbox_custom.empty?
-    config.vm.provider :virtualbox do |vb|
-      vb.customize [
-        "modifyvm", :id,
-        *vbox_custom
-      ]
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    if not vbox_custom.empty?
+      vb.customize [ "modifyvm", :id, *vbox_custom ]
     end
   end
 


### PR DESCRIPTION
The vm sometimes runs into networking problems when the user restarts without reprovisioning, because dhclient is clobbering resolv.conf.  Currently we're replacing resolv.conf [here](https://github.com/CPAN-API/metacpan-puppet/blob/master/modules/metacpan/manifests/system/configs.pp#L8); I think the proper thing would be to replace /etc/dchp/dhclient.conf so that it behaves correctly.  However I had trouble getting this to work with ipv6 addresses.  

This patch just tells vagrant to use the host's dns.