### PR TITLE
Set vagrant default provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,5 @@
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+
 Vagrant.configure("2") do |config|
   config.vm.box_url = "http://vmbox.metacpan.org/mcwheezy_vm_debian_005_32.box"
   config.vm.box = "mcbase_005"


### PR DESCRIPTION
In the Fedora vagrant package the default provider is set to libvirt (because Fedora doesn't package VirtualBox), which breaks metacpan-developer. This change forces the provider to virtualbox.